### PR TITLE
Add checkout action to github action release

### DIFF
--- a/.github/workflows/R_CMD_check_Hades.yaml
+++ b/.github/workflows/R_CMD_check_Hades.yaml
@@ -94,6 +94,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+      - uses: actions/checkout@v2
       - name: First
         if: ${{ github.event_name != 'pull_request' && github.branch == 'master' }}
         run: |


### PR DESCRIPTION
Added - uses: actions/checkout@v2 to the github action "Release" so that the compare_versions perl script is accessible.

However since this only runs on pull requests to master I'm not sure how to test it.